### PR TITLE
allow NA_character_ in input vector for get_species()

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -67,7 +67,7 @@ date_to_st_week <- function(dates) {
 #' @examples
 #' get_species(c("Black-capped Chickadee", "Poecile gambeli", "carchi"))
 get_species <- function(x) {
-  stopifnot(is.character(x), all(!is.na(x)))
+  stopifnot(is.character(x))
   r <- ebirdst::ebirdst_runs
   x <- tolower(trimws(x))
 

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -1,0 +1,11 @@
+context("Utility functions")
+
+skip_on_cran()
+
+test_that("get_species empty vector", {
+  expect_equal(get_species(character(0)), character(0))
+})
+
+test_that("get_species NA_character_", {
+  expect_equal(get_species(NA_character_), NA_character_)
+})


### PR DESCRIPTION
I am suggesting different NA handling for get_species().  The function seems to process NAs intuitively if we simply allow NAs in the character vector.

Existing:

```
> get_species(
+     character(0)
+ )
character(0)
> 
> get_species(
+     NA_character_
+ )
Error in get_species(NA_character_) : all(!is.na(x)) is not TRUE
> get_species(
+     c(NA_character_, 'Red-winged Blackbird')
+ )
Error in get_species(c(NA_character_, "Red-winged Blackbird")) : 
  all(!is.na(x)) is not TRUE

```

Proposed:
```
> get_species(
+     character(0)
+ )
character(0)
> 
> get_species(
+     NA_character_
+ )
[1] NA
> 
> get_species(
+     c(NA_character_, 'Red-winged Blackbird')
+ )
[1] NA       "rewbla"

```