### PR TITLE
Use vapply instead of apply to check column types

### DIFF
--- a/R/sample.R
+++ b/R/sample.R
@@ -263,7 +263,7 @@ grid_sample_stratified <- function(
     stopifnot(is.numeric(jitter_sd), length(jitter_sd) == 1, jitter_sd >= 0)
 
     # ensure columns to jitter are numeric
-    col_types <- apply(x, MARGIN = 2, FUN = class)
+    col_types <- vapply(x, class, character(1))
     col_types <- col_types[jitter_columns]
     not_numeric <- names(col_types)[!col_types %in% c("numeric", "integer")]
     if (length(not_numeric) > 0) {


### PR DESCRIPTION
The type checking [here](https://github.com/ebird/ebirdst/blob/920ca4bb66c937c8db514ad6442b8742c91376b1/R/sample.R#L266) will fail if the data frame contains columns of multiple types (which also sort of negates the need for checking every column).
